### PR TITLE
Made winlaunch Python 3 compatible

### DIFF
--- a/winlaunch.py
+++ b/winlaunch.py
@@ -67,9 +67,9 @@ def launch(cmd):
 	if len(new_wids) < 1:
 		print('ERROR: launch(): too few window ids found')
 		return None
-	LAUNCHED.append([cmd, wid])
 	wid = int(new_wids[0], 16)
 	pid = win_pid(wid)
+	LAUNCHED.append([cmd, wid])
 	return wid, pid
 
 


### PR DESCRIPTION
Since Python 3 variables in mappings (see line 63) are not kept in the current scope, so variable `wid` does not exist when trying to add it to `LAUNCHED` moving it 2 lines down fixes the problem. 
